### PR TITLE
PRO-4152: allow registryLocation to be set on base CaseData object

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform.probate'
-version '0.0.18'
+version '0.0.19'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/CaseData.java
@@ -33,4 +33,6 @@ public abstract class CaseData {
     public abstract List<CollectionMember<CasePayment>> getPayments();
 
     public abstract void setPayments(List<CollectionMember<CasePayment>> payments);
+
+    public abstract void setRegistryLocation(RegistryLocation registryLocation);
 }

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/RegistryLocation.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/RegistryLocation.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 import static uk.gov.hmcts.reform.probate.model.cases.RegistryLocation.Constants.BIRMINGHAM_NAME;
 import static uk.gov.hmcts.reform.probate.model.cases.RegistryLocation.Constants.BRIGHTON_NAME;
 import static uk.gov.hmcts.reform.probate.model.cases.RegistryLocation.Constants.CARDIFF_NAME;
@@ -31,6 +33,14 @@ public enum RegistryLocation {
 
     @Getter
     private final String name;
+
+    public static RegistryLocation findRegistryLocationByName(String name) {
+        return Arrays.stream(RegistryLocation.values())
+                .filter(e -> e.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Unsupported RegistryLocation %s.", name)));
+    }
 
     public static class Constants {
 

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/cases/CaseTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/cases/CaseTypeTest.java
@@ -33,7 +33,6 @@ public class CaseTypeTest {
 
     public class RandomCaseData extends CaseData {
 
-
         @Override
         public List<CollectionMember<CasePayment>> getPayments() {
             return null;
@@ -41,6 +40,11 @@ public class CaseTypeTest {
 
         @Override
         public void setPayments(List<CollectionMember<CasePayment>> payments) {
+
+        }
+
+        @Override
+        public void setRegistryLocation(RegistryLocation registryLocation) {
 
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/cases/RegistryLocationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/cases/RegistryLocationTest.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.probate.model.cases;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class RegistryLocationTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldGetRegistryLocationByName() {
+        RegistryLocation registryLocation;
+
+        registryLocation = RegistryLocation.findRegistryLocationByName("birmingham");
+        assertThat(registryLocation, is(RegistryLocation.BIRMINGHAM));
+
+        registryLocation = RegistryLocation.findRegistryLocationByName("OXFORD");
+        assertThat(registryLocation, is(RegistryLocation.OXFORD));
+
+        registryLocation = RegistryLocation.findRegistryLocationByName("ManchesTer");
+        assertThat(registryLocation, is(RegistryLocation.MANCHESTER));
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionWhenRegistryLocationDoesNotExist() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Unsupported RegistryLocation Birminghen.");
+
+        RegistryLocation registryLocation = RegistryLocation.findRegistryLocationByName("Birminghen");
+        fail();
+    }
+
+}


### PR DESCRIPTION
allow registryLocation to be set on base CaseData object


