### PR TITLE
PRO-5804: Added some extra derived fields missing in the last update …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform.probate'
-version '0.0.65'
+version '0.0.66'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationData.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationData.java
@@ -173,6 +173,18 @@ public class GrantOfRepresentationData extends CaseData {
 
     @JsonDeserialize(using = YesNoDeserializer.class)
     @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean allDeceasedChildrenOverEighteen;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean anyDeceasedChildrenDieBeforeDeceased;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean anyDeceasedGrandChildrenUnderEighteen;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
     private Boolean childrenDied;
 
     @JsonProperty("childrenDiedOverEighteen")
@@ -332,6 +344,10 @@ public class GrantOfRepresentationData extends CaseData {
     @JsonDeserialize(using = YesNoDeserializer.class)
     @JsonSerialize(using = YesNoSerializer.class)
     private Boolean primaryApplicantSameWillName;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean primaryApplicantHasAlias;
 
     private String primaryApplicantAlias;
 
@@ -647,6 +663,14 @@ public class GrantOfRepresentationData extends CaseData {
     private LocalDate dateOfDivorcedCPJudicially;
 
     private String courtOfDecree;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean boEmailRequestInfoNotificationRequested;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean boSendToBulkPrintRequested;
 
     /* END: Additional Bulk Scanning PA1A PA1P Form fields for case creation */
 

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/GrantOfRepresentationCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/GrantOfRepresentationCreator.java
@@ -257,7 +257,6 @@ public class GrantOfRepresentationCreator {
         grantOfRepresentationData.setChildrenUnderEighteenSurvivedText("2");
         grantOfRepresentationData.setDeceasedAnyChildren(false);
         grantOfRepresentationData.setDeceasedAnyOtherNames(false);
-
         grantOfRepresentationData.setRegistryLocation(RegistryLocation.BIRMINGHAM);
         grantOfRepresentationData.setDeceasedHasAssetsOutsideUK(true);
         grantOfRepresentationData.setAssetsOutsideNetValue(10050L);
@@ -295,11 +294,21 @@ public class GrantOfRepresentationCreator {
         grantOfRepresentationData.setScannedDocuments((List<CollectionMember<ScannedDocument>>)
                 Arrays.asList(scannedDocumentMember1, scannedDocumentMember2));
         addExecutorNotApplying(grantOfRepresentationData, "Bob Dylan", ExecutorNotApplyingReason.MENTALLY_INCAPABLE);
+        addExecutorNotApplying(grantOfRepresentationData, "Peter Smith", ExecutorNotApplyingReason.POWER_RESERVED);
         addAdoptiveRelative(grantOfRepresentationData, "Bob Taylor", "Cousin", InOut.OUT);
+        addAdoptiveRelative(grantOfRepresentationData, "Mark Ronson", "Cousin", InOut.IN);
         grantOfRepresentationData.setAdopted(true);
         grantOfRepresentationData.setHalfBloodNeicesAndNephews(true);
         grantOfRepresentationData.setHalfBloodNeicesAndNephewsOverEighteen("1");
         grantOfRepresentationData.setNotifiedApplicants(false);
+        grantOfRepresentationData.setPrimaryApplicantAdoptionInEnglandOrWales(false);
+        grantOfRepresentationData.setChildrenDied(true);
+        grantOfRepresentationData.setChildrenDiedOverEighteenText("1");
+        grantOfRepresentationData.setChildrenOverEighteenSurvivedText("2");
+        grantOfRepresentationData.setGrandChildrenSurvived(true);
+        grantOfRepresentationData.setAllDeceasedChildrenOverEighteen(true);
+        grantOfRepresentationData.setAnyDeceasedChildrenDieBeforeDeceased(false);
+        grantOfRepresentationData.setAnyDeceasedGrandChildrenUnderEighteen(true);
         return grantOfRepresentationData;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/payments/CardPaymentRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/payments/CardPaymentRequestTest.java
@@ -1,0 +1,92 @@
+package uk.gov.hmcts.reform.probate.model.payments;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class CardPaymentRequestTest {
+
+    private static final BigDecimal CARD_PAYMENT_AMOUNT = new BigDecimal(120.00);
+    private static final BigDecimal CARD_PAYMENT_AMOUNT_2 = new BigDecimal(90.00);
+    private static final String CARD_PAYMENT_DESCRIPTION = "Debit card";
+    private static final String CARD_PAYMENT_CCD_CASE_NUMBER = "1234-5678-9012-3456";
+    private static final String CARD_PAYMENT_CASE_REFERNCE = "12345";
+    private static final String CARD_PAYMENT_SERVICE = "GovPay";
+    private static final String CARD_PAYMENT_CURRENCY = "Pounds";
+    private static final String CARD_PAYMENT_SITEID = "Probate";
+
+    private static List<FeeDto> CARD_PAYMENT_FEES = new ArrayList();
+
+    CardPaymentRequest cardPaymentRequest;
+
+    CardPaymentRequest cardPaymentRequestMatch;
+
+    @Before
+    public void setUp() throws Exception {
+        CARD_PAYMENT_FEES.add(FeeDto.builder()
+                .calculatedAmount(CARD_PAYMENT_AMOUNT)
+                .ccdCaseNumber(CARD_PAYMENT_CCD_CASE_NUMBER)
+                .code("121")
+                .reference("Payment")
+                .build());
+
+        cardPaymentRequest = CardPaymentRequest.builder()
+                .caseReference(CARD_PAYMENT_CASE_REFERNCE)
+                .amount(CARD_PAYMENT_AMOUNT)
+                .ccdCaseNumber(CARD_PAYMENT_CCD_CASE_NUMBER)
+                .description(CARD_PAYMENT_DESCRIPTION)
+                .service(CARD_PAYMENT_SERVICE)
+                .currency(CARD_PAYMENT_CURRENCY)
+                .siteId(CARD_PAYMENT_SITEID)
+                .fees(CARD_PAYMENT_FEES)
+                .build();
+
+        cardPaymentRequestMatch = CardPaymentRequest.builder()
+                .caseReference(CARD_PAYMENT_CASE_REFERNCE)
+                .amount(CARD_PAYMENT_AMOUNT)
+                .ccdCaseNumber(CARD_PAYMENT_CCD_CASE_NUMBER)
+                .description(CARD_PAYMENT_DESCRIPTION)
+                .service(CARD_PAYMENT_SERVICE)
+                .currency(CARD_PAYMENT_CURRENCY)
+                .siteId(CARD_PAYMENT_SITEID)
+                .fees(CARD_PAYMENT_FEES)
+                .build();
+    }
+
+    @Test
+    public void shouldSetValuesCorrectlyForPayment() throws IOException {
+        assertEquals(CARD_PAYMENT_CASE_REFERNCE, cardPaymentRequest.getCaseReference());
+        assertEquals(CARD_PAYMENT_AMOUNT, cardPaymentRequest.getAmount());
+        assertEquals(CARD_PAYMENT_CCD_CASE_NUMBER, cardPaymentRequest.getCcdCaseNumber());
+        assertEquals(CARD_PAYMENT_DESCRIPTION, cardPaymentRequest.getDescription());
+        assertEquals(CARD_PAYMENT_SERVICE, cardPaymentRequest.getService());
+        assertEquals(CARD_PAYMENT_CURRENCY, cardPaymentRequest.getCurrency());
+        assertEquals(CARD_PAYMENT_SITEID, cardPaymentRequest.getSiteId());
+        assertThat(CARD_PAYMENT_FEES, is(equalTo(cardPaymentRequest.getFees())));
+    }
+
+    @Test
+    public void shouldComparePaymentsToEnsureTheyMatch() throws IOException {
+        assertThat(cardPaymentRequest, is(equalTo(cardPaymentRequestMatch)));
+        assertTrue(cardPaymentRequest.equals(cardPaymentRequestMatch));
+    }
+
+    @Test
+    public void shouldComparePaymentsToEnsureTheyDontMatch() throws IOException {
+        cardPaymentRequestMatch.setAmount(CARD_PAYMENT_AMOUNT_2);
+        assertThat(cardPaymentRequest, is(not(cardPaymentRequestMatch)));
+        assertFalse(cardPaymentRequest.equals(cardPaymentRequestMatch));
+    }
+}

--- a/src/test/resources/bulkScanIntestacyGrantOfRepresentation.json
+++ b/src/test/resources/bulkScanIntestacyGrantOfRepresentation.json
@@ -33,10 +33,15 @@
   "deceasedDivorcedInEnglandOrWales": "No",
   "deceasedOtherChildren": "Yes",
   "deceasedAnyChildren": "No",
-  "childrenDied": "No",
-  "childrenOverEighteenSurvived": "Yes",
+  "childrenDied": "Yes",
+  "childrenOverEighteenSurvived": "2",
   "childrenUnderEighteenSurvived": "2",
   "grandChildrenSurvivedUnderEighteen": "No",
+  "allDeceasedChildrenOverEighteen": "Yes",
+  "anyDeceasedChildrenDieBeforeDeceased": "No",
+  "anyDeceasedGrandChildrenUnderEighteen": "Yes",
+  "childrenDiedOverEighteen": "1",
+  "grandChildrenSurvived": "Yes",
   "ihtFormId": "IHT205",
   "ihtFormCompletedOnline": "Yes",
   "ihtNetValue": "100000",
@@ -50,7 +55,7 @@
   "primaryApplicantSurname": "Snow",
   "primaryApplicantPhoneNumber": "123455678",
   "primaryApplicantRelationshipToDeceased": "adoptedChild",
-  "primaryApplicantAdoptionInEnglandOrWales": "Yes",
+  "primaryApplicantAdoptionInEnglandOrWales": "No",
   "paperForm": "No",
   "deceasedHasAssetsOutsideUK": "Yes",
   "assetsOutsideNetValue": "10050",
@@ -90,7 +95,6 @@
   "notifiedApplicants": "No",
   "halfBloodNeicesAndNephews": "Yes",
   "halfBloodNeicesAndNephewsOverEighteen": "1",
-
   "applyingAsAnAttorney": "Yes",
   "attorneyNamesAndAddress": [
     {
@@ -115,6 +119,13 @@
         "notApplyingExecutorName": "Bob Dylan",
         "notApplyingExecutorReason": "MentallyIncapable"
       }
+    },
+    {
+      "id": "1",
+      "value": {
+        "notApplyingExecutorName": "Peter Smith",
+        "notApplyingExecutorReason": "PowerReserved"
+      }
     }
   ],
   "adoptiveRelatives": [
@@ -124,6 +135,14 @@
         "name": "Bob Taylor",
         "relationship": "Cousin",
         "adoptedInOrOut": "OUT"
+      }
+    },
+    {
+      "id": "1",
+      "value": {
+        "name": "Mark Ronson",
+        "relationship": "Cousin",
+        "adoptedInOrOut": "IN"
       }
     }
   ],


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5804


### Change description ###
Adding missing derived fields and primaryApplicantHasAlias which is passed in from the PA1A and PA1P OCR fields.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
