### PR TITLE
PRO-6828: New update.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/SolsPaymentMethods.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/SolsPaymentMethods.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.probate.model.cases;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static uk.gov.hmcts.reform.probate.model.cases.SolsPaymentMethods.Constants.CHEQUE_VALUE;
+import static uk.gov.hmcts.reform.probate.model.cases.SolsPaymentMethods.Constants.FEE_ACCOUNT_VALUE;
+
+@RequiredArgsConstructor
+public enum SolsPaymentMethods {
+
+    @JsonProperty(CHEQUE_VALUE) CHEQUE(CHEQUE_VALUE),
+    @JsonProperty(FEE_ACCOUNT_VALUE) FEE_ACCOUNT(FEE_ACCOUNT_VALUE);
+
+    @Getter
+    private final String description;
+
+    public static class Constants {
+
+        public static final String CHEQUE_VALUE = "cheque";
+
+        public static final String FEE_ACCOUNT_VALUE = "fee account";
+
+        public static final String ALLOWABLE_VALUES = CHEQUE_VALUE + "," + FEE_ACCOUNT_VALUE;
+
+        private Constants() {
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/caveat/CaveatData.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/caveat/CaveatData.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.probate.model.cases.CasePayment;
 import uk.gov.hmcts.reform.probate.model.cases.CollectionMember;
 import uk.gov.hmcts.reform.probate.model.cases.FullAliasName;
 import uk.gov.hmcts.reform.probate.model.cases.RegistryLocation;
+import uk.gov.hmcts.reform.probate.model.cases.SolsPaymentMethods;
 import uk.gov.hmcts.reform.probate.model.cases.UploadDocument;
 import uk.gov.hmcts.reform.probate.model.jackson.YesNoDeserializer;
 import uk.gov.hmcts.reform.probate.model.jackson.YesNoSerializer;
@@ -150,6 +151,16 @@ public class CaveatData extends CaseData {
     @JsonDeserialize(using = YesNoDeserializer.class)
     @JsonSerialize(using = YesNoSerializer.class)
     private Boolean languagePreferenceWelsh;
+
+    private String solsSolicitorFirmName;
+
+    private String solsSolicitorPhoneNumber;
+
+    private String solsSolicitorAppReference;
+
+    private SolsPaymentMethods solsPaymentMethods;
+
+    private String solsFeeAccountNumber;
 
     @Transient
     @AssertTrue(message = "deceasedDateOfBirth must be before deceasedDateOfDeath")

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationData.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationData.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.reform.probate.model.cases.MaritalStatus;
 import uk.gov.hmcts.reform.probate.model.cases.ProbateCalculatedFees;
 import uk.gov.hmcts.reform.probate.model.cases.RegistryLocation;
 import uk.gov.hmcts.reform.probate.model.cases.SolsAliasName;
+import uk.gov.hmcts.reform.probate.model.cases.SolsPaymentMethods;
 import uk.gov.hmcts.reform.probate.model.cases.UploadDocument;
 import uk.gov.hmcts.reform.probate.model.jackson.YesNoDeserializer;
 import uk.gov.hmcts.reform.probate.model.jackson.YesNoSerializer;
@@ -465,6 +466,27 @@ public class GrantOfRepresentationData extends CaseData {
     private Address solsSolicitorAddress;
 
     private String solsSolicitorFirmName;
+
+    @JsonDeserialize(using = YesNoDeserializer.class)
+    @JsonSerialize(using = YesNoSerializer.class)
+    private Boolean solsSolicitorIsApplying;
+
+    private SolsPaymentMethods solsPaymentMethods;
+
+    private String solsFeeAccountNumber;
+
+    @SuppressWarnings({"AbbreviationAsWordInName"})
+    private String solsSOTName;
+
+    @SuppressWarnings({"AbbreviationAsWordInName"})
+    private String solsSOTForenames;
+
+    @SuppressWarnings({"AbbreviationAsWordInName"})
+    private String solsSOTSurname;
+
+    private String solsSolicitorEmail;
+
+    private String solsSolicitorPhoneNumber;
 
     // Will this be required if we remove submissionReference??
     @SuppressWarnings({"AbbreviationAsWordInName"})

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/CaveatCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/CaveatCreator.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.reform.probate.model.cases.ApplicationType;
 import uk.gov.hmcts.reform.probate.model.cases.CollectionMember;
 import uk.gov.hmcts.reform.probate.model.cases.FullAliasName;
 import uk.gov.hmcts.reform.probate.model.cases.RegistryLocation;
+import uk.gov.hmcts.reform.probate.model.cases.SolsPaymentMethods;
 import uk.gov.hmcts.reform.probate.model.cases.caveat.CaveatData;
 
 import java.time.LocalDate;
@@ -39,15 +40,19 @@ public class CaveatCreator {
         return caveatData;
     }
 
-    public static CaveatData createCaveatCaseWithBulkScanData() {
-        CaveatData caveatData = createCaveatCase();
-        CollectionMember<ScannedDocument> scannedDocumentMember1 = new CollectionMember<>();
-        scannedDocumentMember1.setValue(getScannedDocument("1"));
-        CollectionMember<ScannedDocument> scannedDocumentMember2 = new CollectionMember<>();
-        scannedDocumentMember2.setValue(getScannedDocument("2"));
-        caveatData.setScannedDocuments((List<CollectionMember<ScannedDocument>>)
-                Arrays.asList(scannedDocumentMember1, scannedDocumentMember2));
-        caveatData.setBulkScanCaseReference("123");
+    public static CaveatData createCaveatCaseWithCitizenBulkScanData() {
+        CaveatData caveatData = setBasicBulkScanData();
+        return caveatData;
+    }
+
+    public static CaveatData createCaveatCaseWithSolicitorBulkScanData() {
+        CaveatData caveatData = setBasicBulkScanData();
+        caveatData.setApplicationType(ApplicationType.SOLICITORS);
+        caveatData.setSolsFeeAccountNumber("PBA-123456");
+        caveatData.setSolsPaymentMethods(SolsPaymentMethods.FEE_ACCOUNT);
+        caveatData.setSolsSolicitorAppReference("APP-123456");
+        caveatData.setSolsSolicitorFirmName("solicitor firm");
+        caveatData.setSolsSolicitorPhoneNumber("0909 909 9909");
         return caveatData;
     }
 
@@ -61,6 +66,20 @@ public class CaveatCreator {
         address.setPostCode(name + " post code");
         address.setCountry(name + " country");
         return address;
+    }
+
+    private static CaveatData setBasicBulkScanData() {
+        CaveatData caveatData = createCaveatCase();
+        caveatData.setRegistryLocation(RegistryLocation.CTSC);
+        caveatData.setPaperForm(Boolean.TRUE);
+        CollectionMember<ScannedDocument> scannedDocumentMember1 = new CollectionMember<>();
+        scannedDocumentMember1.setValue(getScannedDocument("1"));
+        CollectionMember<ScannedDocument> scannedDocumentMember2 = new CollectionMember<>();
+        scannedDocumentMember2.setValue(getScannedDocument("2"));
+        caveatData.setScannedDocuments((List<CollectionMember<ScannedDocument>>)
+                Arrays.asList(scannedDocumentMember1, scannedDocumentMember2));
+        caveatData.setBulkScanCaseReference("123");
+        return caveatData;
     }
 
     private static ScannedDocument getScannedDocument(String docReference) {

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/GrantOfRepresentationCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/GrantOfRepresentationCreator.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.probate.model.cases.CollectionMember;
 import uk.gov.hmcts.reform.probate.model.cases.MaritalStatus;
 import uk.gov.hmcts.reform.probate.model.cases.RegistryLocation;
 import uk.gov.hmcts.reform.probate.model.cases.SolsAliasName;
+import uk.gov.hmcts.reform.probate.model.cases.SolsPaymentMethods;
 import uk.gov.hmcts.reform.probate.model.cases.grantofrepresentation.Declaration;
 import uk.gov.hmcts.reform.probate.model.cases.grantofrepresentation.ExecutorApplying;
 import uk.gov.hmcts.reform.probate.model.cases.grantofrepresentation.ExecutorNotApplying;
@@ -174,9 +175,6 @@ public class GrantOfRepresentationCreator {
         grantOfRepresentationData.setSolsSolicitorAddress(solicitorAddress);
         grantOfRepresentationData.setSolsSolicitorAppReference("Solicitor Application Reference");
         grantOfRepresentationData.setSolsSolicitorFirmName("Solicitor Firm Name");
-        grantOfRepresentationData.setSolsSolicitorAddress(solicitorAddress);
-        grantOfRepresentationData.setSolsSolicitorAppReference("Solicitor Application Reference");
-        grantOfRepresentationData.setSolsSolicitorFirmName("Solicitor Firm Name");
     }
 
     private static void createAttorneyObBehalfOfDetails(GrantOfRepresentationData grantOfRepresentationData) {
@@ -285,7 +283,25 @@ public class GrantOfRepresentationCreator {
         return grantOfRepresentationData;
     }
 
-    public static GrantOfRepresentationData createIntestacyCaseWithBulkScanData() {
+    public static GrantOfRepresentationData createCitizenIntestacyCaseWithBulkScanData() {
+        GrantOfRepresentationData grantOfRepresentationData = setBasicBulkScanData();
+        grantOfRepresentationData.setApplicationType(ApplicationType.PERSONAL);
+        grantOfRepresentationData.setSolsSolicitorAddress(null);
+        grantOfRepresentationData.setSolsSolicitorAppReference(null);
+        grantOfRepresentationData.setSolsSolicitorFirmName(null);
+        return grantOfRepresentationData;
+    }
+
+    public static GrantOfRepresentationData createSolicitorIntestacyCaseWithBulkScanData() {
+        GrantOfRepresentationData grantOfRepresentationData = setBasicBulkScanData();
+        grantOfRepresentationData.setApplicationType(ApplicationType.SOLICITORS);
+        grantOfRepresentationData.setSolsFeeAccountNumber("PBA-123456");
+        grantOfRepresentationData.setSolsPaymentMethods(SolsPaymentMethods.FEE_ACCOUNT);
+        grantOfRepresentationData.setSolsSolicitorPhoneNumber("0909 909 9909");
+        return grantOfRepresentationData;
+    }
+
+    private static GrantOfRepresentationData setBasicBulkScanData() {
         GrantOfRepresentationData grantOfRepresentationData = createIntestacyCase();
         CollectionMember<ScannedDocument> scannedDocumentMember1 = new CollectionMember<>();
         scannedDocumentMember1.setValue(getScannedDocument("1"));
@@ -297,6 +313,9 @@ public class GrantOfRepresentationCreator {
         addExecutorNotApplying(grantOfRepresentationData, "Peter Smith", ExecutorNotApplyingReason.POWER_RESERVED);
         addAdoptiveRelative(grantOfRepresentationData, "Bob Taylor", "Cousin", InOut.OUT);
         addAdoptiveRelative(grantOfRepresentationData, "Mark Ronson", "Cousin", InOut.IN);
+        grantOfRepresentationData.setRegistryLocation(RegistryLocation.CTSC);
+        grantOfRepresentationData.setPaperForm(Boolean.TRUE);
+        grantOfRepresentationData.setBulkScanCaseReference("123");
         grantOfRepresentationData.setAdopted(true);
         grantOfRepresentationData.setHalfBloodNeicesAndNephews(true);
         grantOfRepresentationData.setHalfBloodNeicesAndNephewsOverEighteen("1");
@@ -309,7 +328,6 @@ public class GrantOfRepresentationCreator {
         grantOfRepresentationData.setAllDeceasedChildrenOverEighteen(true);
         grantOfRepresentationData.setAnyDeceasedChildrenDieBeforeDeceased(false);
         grantOfRepresentationData.setAnyDeceasedGrandChildrenUnderEighteen(true);
-        grantOfRepresentationData.setBulkScanCaseReference("123");
         return grantOfRepresentationData;
     }
 
@@ -361,7 +379,7 @@ public class GrantOfRepresentationCreator {
         return ScannedDocument.builder().controlNumber(docReference + "000")
             .fileName(docReference + "000.pdf")
             .type("form")
-            .subtype("PA1P")
+            .subtype("PA1A")
             .scannedDate(dateTime)
             .exceptionRecordReference(null)
             .deliveryDate(dateTime)

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/cases/caveat/CaveatDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/cases/caveat/CaveatDataTest.java
@@ -22,20 +22,26 @@ public class CaveatDataTest {
 
     private CaveatData caveatData;
 
-    private CaveatData bulkScanCaveatData;
+    private CaveatData bulkScanCitizenCaveatData;
+
+    private CaveatData bulkScanSolicitorCaveatData;
 
     private String json;
 
     private String bulkScanJson;
 
+    private String bulkScanSolicitorJson;
+
     @Before
     public void setUp() throws Exception {
         json = TestUtils.getJsonFromFile("caveatData.json");
-        bulkScanJson = TestUtils.getJsonFromFile("bulkScanCaveatData.json");
+        bulkScanJson = TestUtils.getJsonFromFile("bulkScanCitizenCaveatData.json");
+        bulkScanSolicitorJson = TestUtils.getJsonFromFile("bulkScanSolicitorCaveatData.json");
         objectMapper = new ObjectMapper();
         objectMapper.disable(FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY);
         caveatData = CaveatCreator.createCaveatCase();
-        bulkScanCaveatData = CaveatCreator.createCaveatCaseWithBulkScanData();
+        bulkScanCitizenCaveatData = CaveatCreator.createCaveatCaseWithCitizenBulkScanData();
+        bulkScanSolicitorCaveatData = CaveatCreator.createCaveatCaseWithSolicitorBulkScanData();
     }
 
     @Test
@@ -54,8 +60,15 @@ public class CaveatDataTest {
 
     @Test
     public void shouldSerializeCaveatDataFromBulkScanCorrectly() throws IOException, JSONException {
-        String actualJson = objectMapper.writeValueAsString(bulkScanCaveatData);
+        String actualJson = objectMapper.writeValueAsString(bulkScanCitizenCaveatData);
 
         JSONAssert.assertEquals(bulkScanJson, actualJson, true);
+    }
+
+    @Test
+    public void shouldSerializeSolicitorCaveatDataFromBulkScanCorrectly() throws IOException, JSONException {
+        String actualJson = objectMapper.writeValueAsString(bulkScanSolicitorCaveatData);
+
+        JSONAssert.assertEquals(bulkScanSolicitorJson, actualJson, true);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationDataIntestacyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationDataIntestacyTest.java
@@ -22,20 +22,30 @@ public class GrantOfRepresentationDataIntestacyTest {
 
     private GrantOfRepresentationData grantOfRepresentationData;
 
-    private GrantOfRepresentationData bulkScanGrantOfRepresentationData;
+    private GrantOfRepresentationData bulkScanCitizenGrantOfRepresentationData;
+
+    private GrantOfRepresentationData bulkScanSolicitorGrantOfRepresentationData;
 
     private String gorJsonFromFile;
 
-    private String bulkScanGorJsonFromFile;
+    private String bulkScanCitizenGorJsonFromFile;
+
+    private String bulkScanSolicitorGorJsonFromFile;
 
     @Before
     public void setUp() throws Exception {
         gorJsonFromFile = TestUtils.getJsonFromFile("intestacyGrantOfRepresentation.json");
-        bulkScanGorJsonFromFile = TestUtils.getJsonFromFile("bulkScanIntestacyGrantOfRepresentation.json");
+        bulkScanCitizenGorJsonFromFile =
+                TestUtils.getJsonFromFile("bulkScanIntestacyCitizenGrantOfRepresentation.json");
+        bulkScanSolicitorGorJsonFromFile =
+                TestUtils.getJsonFromFile("bulkScanIntestacySolicitorGrantOfRepresentation.json");
         objectMapper = new ObjectMapper();
         objectMapper.disable(FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY);
         grantOfRepresentationData = GrantOfRepresentationCreator.createIntestacyCase();
-        bulkScanGrantOfRepresentationData = GrantOfRepresentationCreator.createIntestacyCaseWithBulkScanData();
+        bulkScanCitizenGrantOfRepresentationData =
+                GrantOfRepresentationCreator.createCitizenIntestacyCaseWithBulkScanData();
+        bulkScanSolicitorGrantOfRepresentationData =
+                GrantOfRepresentationCreator.createSolicitorIntestacyCaseWithBulkScanData();
     }
 
     @Test
@@ -53,10 +63,18 @@ public class GrantOfRepresentationDataIntestacyTest {
     }
 
     @Test
-    public void shouldSerializeGrantOfRepresentationDataFromBulkScanCorrectly() throws IOException, JSONException {
-        String actualJson = objectMapper.writeValueAsString(bulkScanGrantOfRepresentationData);
+    public void shouldSerializeCitizenGrantOfRepresentationDataFromBulkScanCorrectly()
+            throws IOException, JSONException {
+        String actualJson = objectMapper.writeValueAsString(bulkScanCitizenGrantOfRepresentationData);
 
-        JSONAssert.assertEquals(bulkScanGorJsonFromFile, actualJson, true);
+        JSONAssert.assertEquals(bulkScanCitizenGorJsonFromFile, actualJson, true);
     }
 
+    @Test
+    public void shouldSerializeSolicitorGrantOfRepresentationDataFromBulkScanCorrectly()
+            throws IOException, JSONException {
+        String actualJson = objectMapper.writeValueAsString(bulkScanSolicitorGrantOfRepresentationData);
+
+        JSONAssert.assertEquals(bulkScanSolicitorGorJsonFromFile, actualJson, true);
+    }
 }

--- a/src/test/resources/bulkScanCitizenCaveatData.json
+++ b/src/test/resources/bulkScanCitizenCaveatData.json
@@ -1,0 +1,72 @@
+{
+  "type": "Caveat",
+  "bulkScanCaseReference": "123",
+  "applicationId": "Id",
+  "applicationType": "Personal",
+  "registryLocation": "ctsc",
+  "deceasedForenames": "deceased forename",
+  "applicationSubmittedDate": "2018-11-20",
+  "deceasedSurname": "deceased surname",
+  "deceasedDateOfDeath": "2018-11-20",
+  "deceasedDateOfBirth": "1966-03-04",
+  "deceasedAnyOtherNames" : "Yes",
+  "deceasedFullAliasNameList": [
+    {
+      "value": {
+        "FullAliasName": "fullAliasName"
+      }
+    }
+  ],
+  "deceasedAddress": {
+    "AddressLine1": "deceased address line 1",
+    "AddressLine2": "deceased address line 2",
+    "AddressLine3": "deceased address line 3",
+    "County": "deceased county",
+    "PostTown": "deceased post town",
+    "PostCode": "deceased post code",
+    "Country": "deceased country"
+  },
+  "caveatorForenames": "caveator forename",
+  "caveatorSurname": "caveator surname",
+  "caveatorEmailAddress": "caveator@email.com",
+  "caveatorAddress": {
+    "AddressLine1": "caveator address line 1",
+    "AddressLine2": "caveator address line 2",
+    "AddressLine3": "caveator address line 3",
+    "County": "caveator county",
+    "PostTown": "caveator post town",
+    "PostCode": "caveator post code",
+    "Country": "caveator country"
+  },
+  "expiryDate": "2019-02-14",
+  "paperForm": "Yes",
+  "scannedDocuments": [
+    {
+      "value": {
+        "controlNumber": "1000",
+        "fileName": "1000.pdf",
+        "type": "form",
+        "subtype": "PA8A",
+        "scannedDate": {"dayOfYear":196,"dayOfWeek":"MONDAY","year":2019,"month":"JULY","nano":789000000,"monthValue":7,"dayOfMonth":15,"hour":12,"minute":34,"second":56,"chronology":{"id":"ISO","calendarType":"iso8601"}},
+        "deliveryDate": {"dayOfYear":196,"dayOfWeek":"MONDAY","year":2019,"month":"JULY","nano":789000000,"monthValue":7,"dayOfMonth":15,"hour":12,"minute":34,"second":56,"chronology":{"id":"ISO","calendarType":"iso8601"}},
+        "url":{"document_url":"http://localhost/1000.pdf","document_binary_url":"http://localhost/1000.pdf","document_filename":"1000.pdf"},
+        "exceptionRecordReference": null
+      }
+    },
+    {
+      "value": {
+        "controlNumber": "2000",
+        "fileName": "2000.pdf",
+        "type": "form",
+        "subtype": "PA8A",
+        "scannedDate": {"dayOfYear":196,"dayOfWeek":"MONDAY","year":2019,"month":"JULY","nano":789000000,"monthValue":7,"dayOfMonth":15,"hour":12,"minute":34,"second":56,"chronology":{"id":"ISO","calendarType":"iso8601"}},
+        "deliveryDate": {"dayOfYear":196,"dayOfWeek":"MONDAY","year":2019,"month":"JULY","nano":789000000,"monthValue":7,"dayOfMonth":15,"hour":12,"minute":34,"second":56,"chronology":{"id":"ISO","calendarType":"iso8601"}},
+        "url":{"document_url":"http://localhost/2000.pdf","document_binary_url":"http://localhost/2000.pdf","document_filename":"2000.pdf"},
+        "exceptionRecordReference": null
+      }
+    }
+  ]
+}
+
+
+

--- a/src/test/resources/bulkScanIntestacyCitizenGrantOfRepresentation.json
+++ b/src/test/resources/bulkScanIntestacyCitizenGrantOfRepresentation.json
@@ -3,7 +3,7 @@
   "bulkScanCaseReference": "123",
   "applicationType": "Personal",
   "primaryApplicantEmailAddress": "jon.snow@thenorth.com",
-  "registryLocation": "Birmingham",
+  "registryLocation": "ctsc",
   "extraCopiesOfGrant": 5,
   "deceasedAddress": {
     "AddressLine1": "Winterfell, Westeros",
@@ -57,7 +57,7 @@
   "primaryApplicantPhoneNumber": "123455678",
   "primaryApplicantRelationshipToDeceased": "adoptedChild",
   "primaryApplicantAdoptionInEnglandOrWales": "No",
-  "paperForm": "No",
+  "paperForm": "Yes",
   "deceasedHasAssetsOutsideUK": "Yes",
   "assetsOutsideNetValue": "10050",
   "payments": [
@@ -76,17 +76,6 @@
   "legacyId": "123456",
   "legacyType": "Legacy LEGACY GRANT",
   "legacyCaseViewUrl": "http://locahost:8080/cases/1",
-  "solsSolicitorAppReference": "Solicitor Application Reference",
-  "solsSolicitorAddress": {
-    "AddressLine1": "Sol Address Line 1",
-    "AddressLine2": "Sol Address Line 2",
-    "AddressLine3": "Sol Address Line 3",
-    "County": "Middlesex",
-    "PostTown": "Harrow",
-    "PostCode": "HA1 4ET",
-    "Country": "UK"
-  },
-  "solsSolicitorFirmName": "Solicitor Firm Name",
   "declarationCheckbox": "Yes",
   "ihtGrossValueField": "100000",
   "ihtNetValueField": "100000",
@@ -153,7 +142,7 @@
         "controlNumber": "1000",
         "fileName": "1000.pdf",
         "type": "form",
-        "subtype": "PA1P",
+        "subtype": "PA1A",
         "scannedDate": {
           "dayOfYear": 196,
           "dayOfWeek": "MONDAY",
@@ -199,7 +188,7 @@
         "controlNumber": "2000",
         "fileName": "2000.pdf",
         "type": "form",
-        "subtype": "PA1P",
+        "subtype": "PA1A",
         "scannedDate": {
           "dayOfYear": 196,
           "dayOfWeek": "MONDAY",

--- a/src/test/resources/bulkScanIntestacySolicitorGrantOfRepresentation.json
+++ b/src/test/resources/bulkScanIntestacySolicitorGrantOfRepresentation.json
@@ -1,0 +1,247 @@
+{
+  "type": "GrantOfRepresentation",
+  "bulkScanCaseReference": "123",
+  "applicationType": "Solicitor",
+  "primaryApplicantEmailAddress": "jon.snow@thenorth.com",
+  "registryLocation": "ctsc",
+  "extraCopiesOfGrant": 5,
+  "deceasedAddress": {
+    "AddressLine1": "Winterfell, Westeros",
+    "PostCode": "SW17 TYH"
+  },
+  "deceasedForenames": "Ned",
+  "deceasedSurname": "Stark",
+  "deceasedDateOfDeath": "2018-01-01",
+  "deceasedDateOfBirth": "1930-01-01",
+  "deceasedMaritalStatus": "marriedCivilPartnership",
+  "deceasedAnyOtherNames": "No",
+  "deceasedAliasNameList": [
+    {
+      "value": {
+        "Forenames": "King",
+        "LastName": "North"
+      }
+    }
+  ],
+  "solsDeceasedAliasNamesList": [
+    {
+      "value": {
+        "SolsAliasname": "King North"
+      }
+    }
+  ],
+  "deceasedSpouseNotApplyingReason": "mentallyIncapable",
+  "deceasedDivorcedInEnglandOrWales": "No",
+  "deceasedOtherChildren": "Yes",
+  "deceasedAnyChildren": "No",
+  "childrenDied": "Yes",
+  "childrenOverEighteenSurvived": "2",
+  "childrenUnderEighteenSurvived": "2",
+  "grandChildrenSurvivedUnderEighteen": "No",
+  "allDeceasedChildrenOverEighteen": "Yes",
+  "anyDeceasedChildrenDieBeforeDeceased": "No",
+  "anyDeceasedGrandChildrenUnderEighteen": "Yes",
+  "childrenDiedOverEighteen": "1",
+  "grandChildrenSurvived": "Yes",
+  "ihtFormId": "IHT205",
+  "ihtFormCompletedOnline": "Yes",
+  "ihtNetValue": "100000",
+  "ihtGrossValue": "100000",
+  "ihtReferenceNumber": "GOT123456",
+  "primaryApplicantAddress": {
+    "AddressLine1": "Pret a Manger St. Georges Hospital Blackshaw Road London SW17 0QT",
+    "PostCode": "SW17 0QT"
+  },
+  "primaryApplicantForenames": "Jon",
+  "primaryApplicantSurname": "Snow",
+  "primaryApplicantPhoneNumber": "123455678",
+  "primaryApplicantRelationshipToDeceased": "adoptedChild",
+  "primaryApplicantAdoptionInEnglandOrWales": "No",
+  "paperForm": "Yes",
+  "deceasedHasAssetsOutsideUK": "Yes",
+  "assetsOutsideNetValue": "10050",
+  "payments": [
+    {
+      "value": {
+        "status": "Success",
+        "date": "2018-12-03",
+        "reference": "RC-1537-1988-5489-1985",
+        "amount": "22050",
+        "method": "online",
+        "transactionId": "r23k178busa0rp2mh27m0vchja",
+        "siteId": "P223"
+      }
+    }
+  ],
+  "legacyId": "123456",
+  "legacyType": "Legacy LEGACY GRANT",
+  "legacyCaseViewUrl": "http://locahost:8080/cases/1",
+  "solsSolicitorAppReference": "Solicitor Application Reference",
+  "solsSolicitorAddress": {
+    "AddressLine1": "Sol Address Line 1",
+    "AddressLine2": "Sol Address Line 2",
+    "AddressLine3": "Sol Address Line 3",
+    "County": "Middlesex",
+    "PostTown": "Harrow",
+    "PostCode": "HA1 4ET",
+    "Country": "UK"
+  },
+  "solsSolicitorFirmName": "Solicitor Firm Name",
+  "solsFeeAccountNumber": "PBA-123456",
+  "solsPaymentMethods": "fee account",
+  "solsSolicitorPhoneNumber": "0909 909 9909",
+  "declarationCheckbox": "Yes",
+  "ihtGrossValueField": "100000",
+  "ihtNetValueField": "100000",
+  "outsideUKGrantCopies": 6,
+  "caseType": "intestacy",
+  "adopted": "Yes",
+  "notifiedApplicants": "No",
+  "halfBloodNeicesAndNephews": "Yes",
+  "halfBloodNeicesAndNephewsOverEighteen": "1",
+  "applyingAsAnAttorney": "Yes",
+  "attorneyOnBehalfOfNameAndAddress": [
+    {
+      "value": {
+        "name": "1st Attorney Harrow",
+        "address": {
+          "AddressLine1": "Attorney Address Line 1",
+          "AddressLine2": "Attorney Address Line 2",
+          "AddressLine3": "Attorney Address Line 3",
+          "County": "Middlesex",
+          "PostTown": "Harrow",
+          "PostCode": "HA1 4ET",
+          "Country": "UK"
+        }
+      }
+    }
+  ],
+  "executorsNotApplying": [
+    {
+      "id": "1",
+      "value": {
+        "notApplyingExecutorName": "Bob Dylan",
+        "notApplyingExecutorReason": "MentallyIncapable"
+      }
+    },
+    {
+      "id": "1",
+      "value": {
+        "notApplyingExecutorName": "Peter Smith",
+        "notApplyingExecutorReason": "PowerReserved"
+      }
+    }
+  ],
+  "adoptiveRelatives": [
+    {
+      "id": "1",
+      "value": {
+        "name": "Bob Taylor",
+        "relationship": "Cousin",
+        "adoptedInOrOut": "out"
+      }
+    },
+    {
+      "id": "1",
+      "value": {
+        "name": "Mark Ronson",
+        "relationship": "Cousin",
+        "adoptedInOrOut": "in"
+      }
+    }
+  ],
+  "scannedDocuments": [
+    {
+      "value": {
+        "controlNumber": "1000",
+        "fileName": "1000.pdf",
+        "type": "form",
+        "subtype": "PA1A",
+        "scannedDate": {
+          "dayOfYear": 196,
+          "dayOfWeek": "MONDAY",
+          "year": 2019,
+          "month": "JULY",
+          "nano": 789000000,
+          "monthValue": 7,
+          "dayOfMonth": 15,
+          "hour": 12,
+          "minute": 34,
+          "second": 56,
+          "chronology": {
+            "id": "ISO",
+            "calendarType": "iso8601"
+          }
+        },
+        "deliveryDate": {
+          "dayOfYear": 196,
+          "dayOfWeek": "MONDAY",
+          "year": 2019,
+          "month": "JULY",
+          "nano": 789000000,
+          "monthValue": 7,
+          "dayOfMonth": 15,
+          "hour": 12,
+          "minute": 34,
+          "second": 56,
+          "chronology": {
+            "id": "ISO",
+            "calendarType": "iso8601"
+          }
+        },
+        "url": {
+          "document_url": "http://localhost/1000.pdf",
+          "document_binary_url": "http://localhost/1000.pdf",
+          "document_filename": "1000.pdf"
+        },
+        "exceptionRecordReference": null
+      }
+    },
+    {
+      "value": {
+        "controlNumber": "2000",
+        "fileName": "2000.pdf",
+        "type": "form",
+        "subtype": "PA1A",
+        "scannedDate": {
+          "dayOfYear": 196,
+          "dayOfWeek": "MONDAY",
+          "year": 2019,
+          "month": "JULY",
+          "nano": 789000000,
+          "monthValue": 7,
+          "dayOfMonth": 15,
+          "hour": 12,
+          "minute": 34,
+          "second": 56,
+          "chronology": {
+            "id": "ISO",
+            "calendarType": "iso8601"
+          }
+        },
+        "deliveryDate": {
+          "dayOfYear": 196,
+          "dayOfWeek": "MONDAY",
+          "year": 2019,
+          "month": "JULY",
+          "nano": 789000000,
+          "monthValue": 7,
+          "dayOfMonth": 15,
+          "hour": 12,
+          "minute": 34,
+          "second": 56,
+          "chronology": {
+            "id": "ISO",
+            "calendarType": "iso8601"
+          }
+        },
+        "url": {
+          "document_url": "http://localhost/2000.pdf",
+          "document_binary_url": "http://localhost/2000.pdf",
+          "document_filename": "2000.pdf"
+        },
+        "exceptionRecordReference": null
+      }
+    }
+  ]
+}

--- a/src/test/resources/bulkScanSolicitorCaveatData.json
+++ b/src/test/resources/bulkScanSolicitorCaveatData.json
@@ -2,8 +2,8 @@
   "type": "Caveat",
   "bulkScanCaseReference": "123",
   "applicationId": "Id",
-  "applicationType": "Personal",
-  "registryLocation": "Oxford",
+  "applicationType": "Solicitor",
+  "registryLocation": "ctsc",
   "deceasedForenames": "deceased forename",
   "applicationSubmittedDate": "2018-11-20",
   "deceasedSurname": "deceased surname",
@@ -38,8 +38,13 @@
     "PostCode": "caveator post code",
     "Country": "caveator country"
   },
+  "solsFeeAccountNumber": "PBA-123456",
+  "solsPaymentMethods": "fee account",
+  "solsSolicitorAppReference": "APP-123456",
+  "solsSolicitorFirmName": "solicitor firm",
+  "solsSolicitorPhoneNumber": "0909 909 9909",
   "expiryDate": "2019-02-14",
-  "paperForm": "No",
+  "paperForm": "Yes",
   "scannedDocuments": [
     {
       "value": {
@@ -67,6 +72,3 @@
     }
   ]
 }
-
-
-


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6828
https://tools.hmcts.net/jira/browse/PRO-6102


### Change description ###
Update to add missing solicitor fields, firm, name, payment and reference to Caveats and Grant of Representation case types. Grant Of Representation also includes the addition of solsSOTSurname and solsSOTForenames.

Tag created and used in branches for Probate back office for PRO-6828 and PRO-6102.
1.0.5.2_PRO-6828-AddSolictorsDetailsToCasesBulkScanPhase2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
