### PR TITLE
PRO-7766: Added bulkScanEnvelope field to CaveatData and GrantOfRepre…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/probate/model/BulkScanEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/BulkScanEnvelope.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.probate.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+
+public class BulkScanEnvelope {
+
+    private final String id;
+
+    private final String action;
+}

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/caveat/CaveatData.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/caveat/CaveatData.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.probate.model.BulkScanEnvelope;
 import uk.gov.hmcts.reform.probate.model.ProbateDocument;
 import uk.gov.hmcts.reform.probate.model.ScannedDocument;
 import uk.gov.hmcts.reform.probate.model.cases.Address;
@@ -147,6 +148,8 @@ public class CaveatData extends CaseData {
     private Boolean autoClosedExpiry;
 
     private String bulkScanCaseReference;
+
+    private List<CollectionMember<BulkScanEnvelope>> bulkScanEnvelopes;
 
     @JsonDeserialize(using = YesNoDeserializer.class)
     @JsonSerialize(using = YesNoSerializer.class)

--- a/src/main/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationData.java
+++ b/src/main/java/uk/gov/hmcts/reform/probate/model/cases/grantofrepresentation/GrantOfRepresentationData.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import uk.gov.hmcts.reform.probate.model.AdoptiveRelative;
 import uk.gov.hmcts.reform.probate.model.AliasReason;
 import uk.gov.hmcts.reform.probate.model.AttorneyNamesAndAddress;
+import uk.gov.hmcts.reform.probate.model.BulkScanEnvelope;
 import uk.gov.hmcts.reform.probate.model.IhtFormType;
 import uk.gov.hmcts.reform.probate.model.ProbateDocument;
 import uk.gov.hmcts.reform.probate.model.Relationship;
@@ -705,6 +706,8 @@ public class GrantOfRepresentationData extends CaseData {
     private Boolean boSendToBulkPrintRequested;
 
     private String bulkScanCaseReference;
+
+    private List<CollectionMember<BulkScanEnvelope>> bulkScanEnvelopes;
 
     @JsonDeserialize(using = LocalDateDeserializer.class)
     @JsonSerialize(using = LocalDateSerializer.class)

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/CaveatCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/CaveatCreator.java
@@ -79,7 +79,17 @@ public class CaveatCreator {
         caveatData.setScannedDocuments((List<CollectionMember<ScannedDocument>>)
                 Arrays.asList(scannedDocumentMember1, scannedDocumentMember2));
         caveatData.setBulkScanCaseReference("123");
+        CollectionMember<BulkScanEnvelope> bulkScanEnvelopeCollectionMember = new CollectionMember<>();
+        bulkScanEnvelopeCollectionMember.setValue(getBulkScanEnvelope());
+        caveatData.setBulkScanEnvelopes((List<CollectionMember<BulkScanEnvelope>>)
+                Arrays.asList(bulkScanEnvelopeCollectionMember));
         return caveatData;
+    }
+
+    private static BulkScanEnvelope getBulkScanEnvelope() {
+        return BulkScanEnvelope.builder().id("1")
+                .action("Action")
+                .build();
     }
 
     private static ScannedDocument getScannedDocument(String docReference) {

--- a/src/test/java/uk/gov/hmcts/reform/probate/model/GrantOfRepresentationCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/probate/model/GrantOfRepresentationCreator.java
@@ -328,7 +328,17 @@ public class GrantOfRepresentationCreator {
         grantOfRepresentationData.setAllDeceasedChildrenOverEighteen(true);
         grantOfRepresentationData.setAnyDeceasedChildrenDieBeforeDeceased(false);
         grantOfRepresentationData.setAnyDeceasedGrandChildrenUnderEighteen(true);
+        CollectionMember<BulkScanEnvelope> bulkScanEnvelopeCollectionMember = new CollectionMember<>();
+        bulkScanEnvelopeCollectionMember.setValue(getBulkScanEnvelope());
+        grantOfRepresentationData.setBulkScanEnvelopes((List<CollectionMember<BulkScanEnvelope>>)
+                Arrays.asList(bulkScanEnvelopeCollectionMember));
         return grantOfRepresentationData;
+    }
+
+    private static BulkScanEnvelope getBulkScanEnvelope() {
+        return BulkScanEnvelope.builder().id("1")
+                .action("Action")
+                .build();
     }
 
     private static void createLegacyDetails(GrantOfRepresentationData grantOfRepresentationData) {

--- a/src/test/resources/bulkScanCitizenCaveatData.json
+++ b/src/test/resources/bulkScanCitizenCaveatData.json
@@ -1,6 +1,14 @@
 {
   "type": "Caveat",
   "bulkScanCaseReference": "123",
+  "bulkScanEnvelopes": [
+    {
+      "value": {
+        "id": "1",
+        "action": "Action"
+      }
+    }
+  ],
   "applicationId": "Id",
   "applicationType": "Personal",
   "registryLocation": "ctsc",

--- a/src/test/resources/bulkScanIntestacyCitizenGrantOfRepresentation.json
+++ b/src/test/resources/bulkScanIntestacyCitizenGrantOfRepresentation.json
@@ -1,6 +1,14 @@
 {
   "type": "GrantOfRepresentation",
   "bulkScanCaseReference": "123",
+  "bulkScanEnvelopes": [
+    {
+      "value": {
+        "id": "1",
+        "action": "Action"
+      }
+    }
+  ],
   "applicationType": "Personal",
   "primaryApplicantEmailAddress": "jon.snow@thenorth.com",
   "registryLocation": "ctsc",

--- a/src/test/resources/bulkScanIntestacySolicitorGrantOfRepresentation.json
+++ b/src/test/resources/bulkScanIntestacySolicitorGrantOfRepresentation.json
@@ -1,6 +1,14 @@
 {
   "type": "GrantOfRepresentation",
   "bulkScanCaseReference": "123",
+  "bulkScanEnvelopes": [
+    {
+      "value": {
+        "id": "1",
+        "action": "Action"
+      }
+    }
+  ],
   "applicationType": "Solicitor",
   "primaryApplicantEmailAddress": "jon.snow@thenorth.com",
   "registryLocation": "ctsc",

--- a/src/test/resources/bulkScanSolicitorCaveatData.json
+++ b/src/test/resources/bulkScanSolicitorCaveatData.json
@@ -1,6 +1,14 @@
 {
   "type": "Caveat",
   "bulkScanCaseReference": "123",
+  "bulkScanEnvelopes": [
+    {
+      "value": {
+        "id": "1",
+        "action": "Action"
+      }
+    }
+  ],
   "applicationId": "Id",
   "applicationType": "Solicitor",
   "registryLocation": "ctsc",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-7766


### Change description ###
bulkScanEnvelope added to caveatData, grantOfRepresentationData and unit tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
